### PR TITLE
Change get /logout to post /logout

### DIFF
--- a/config/routes.js
+++ b/config/routes.js
@@ -1,6 +1,6 @@
 module.exports.routes = {
   'post /register': 'UserController.create',
-  'get /logout': 'AuthController.logout',
+  'post /logout': 'AuthController.logout',
 
   'post /auth/local': 'AuthController.callback',
   'post /auth/local/:action': 'AuthController.callback',


### PR DESCRIPTION
For minor security purposes, allow /logout only via POST instead of GET.