### PR TITLE
Don't require 2 times passport, and require lodash

### DIFF
--- a/api/policies/passport.js
+++ b/api/policies/passport.js
@@ -1,5 +1,3 @@
-var passport = require('passport');
-
 /**
  * Passport Middleware
  *
@@ -23,11 +21,14 @@ var passport = require('passport');
  * @param {Object}   res
  * @param {Function} next
  */
-var http = require('http');
+var http = require('http'),
+  passport = require('passport'),
+  _ = require('lodash');
+  
 var methods = ['login', 'logIn', 'logout', 'logOut', 'isAuthenticated', 'isUnauthenticated'];
 
 module.exports = function (req, res, next) {
-  var passport = require('passport');
+  
 
   // Initialize Passport
   passport.initialize()(req, res, function () {


### PR DESCRIPTION
Debug error throwed on login, with sails 0.12.3 : 
```
error: Sending 500 ("Server Error") response: 
 TypeError: Cannot read property 'each' of undefined
    at /node_modules/sails-auth/dist/api/policies/passport.js:41:10
    at SessionStrategy.strategy.pass (/node_modules/sails-auth/node_modules/passport/lib/middleware/authenticate.js:325:9)
    at SessionStrategy.authenticate (/node_modules/sails-auth/node_modules/passport/lib/strategies/session.js:71:10)
    at attempt (/node_modules/sails-auth/node_modules/passport/lib/middleware/authenticate.js:348:16)
    at authenticate (/node_modules/sails-auth/node_modules/passport/lib/middleware/authenticate.js:349:7)
    at /node_modules/sails-auth/dist/api/policies/passport.js:37:23
    at initialize (/node_modules/sails-auth/node_modules/passport/lib/middleware/initialize.js:53:5)
    at module.exports (/node_modules/sails-auth/dist/api/policies/passport.js:35:24)
    at routeTargetFnWrapper (/node_modules/sails/lib/router/bind.js:176:5)
    at callbacks (/node_modules/express/lib/router/index.js:164:37)
    at param (/node_modules/express/lib/router/index.js:138:11)
    at param (/node_modules/express/lib/router/index.js:135:11)
    at pass (/node_modules/express/lib/router/index.js:145:5)
    at nextRoute (/node_modules/express/lib/router/index.js:100:7)
    at callbacks (/node_modules/express/lib/router/index.js:167:11)
    at module.exports (/node_modules/sails-auth/dist/api/policies/basicAuth.js:13:12) [TypeError: Cannot read property 'each' of undefined]
```