### PR TITLE
Add new Delegated Authentication Protocol

### DIFF
--- a/api/controllers/AuthController.js
+++ b/api/controllers/AuthController.js
@@ -77,9 +77,12 @@ module.exports = {
       }
     }
 
-    sails.services.passport.callback(req, res, function (err, user) {
+    sails.services.passport.callback(req, res, function (err, user, info, status) {
       if (err || !user) {
-        sails.log.warn(user, err);
+        sails.log.warn(user, err, info, status);
+		  if(!err && info) {
+			  return negotiateError(info);
+		  }
         return negotiateError(err);
       }
 

--- a/api/services/protocols/delegated.js
+++ b/api/services/protocols/delegated.js
@@ -1,0 +1,37 @@
+var _ = require('lodash');
+//const util = require('util');
+
+/**
+ * Delegated Authentication Protocol
+ *
+ * Authentication is delegated by the Strategy to an external provider
+ * but handled locally (e.g. makes request internally to external provider)
+ * unlike OAuth or similar which redirects to the external provider.
+ * On success the authenticated user is connected to a local user (created if
+ * necessary) in a similar manner to OAuth.
+ *
+ * @param {Object}   req
+ * @param {Object}   userprofile
+ * @param {Function} next
+ */
+
+module.exports = function (req, userprofile, next) {
+
+	//sails.log.debug('delegated: connecting user', util.inspect(userprofile));
+	//sails.log.debug('delegated: session is ', util.inspect(req.session));
+
+	var query = {
+		identifier: userprofile.id,
+		protocol: 'delegated'
+	};
+
+	sails.services.passport.connect(req, query, userprofile, next);
+
+	/*
+	sails.services.passport.connect(req, query, userprofile, function(err, user) {
+		if(user!=null) sails.log.debug('delegated: got user', util.inspect(user));
+		user.profile = userprofile;
+		next(err, user);
+	});
+	*/
+};

--- a/api/services/protocols/index.js
+++ b/api/services/protocols/index.js
@@ -17,5 +17,6 @@ module.exports = {
   bearer: require('./bearer'),
   oauth: require('./oauth'),
   oauth2: require('./oauth2'),
-  openid: require('./openid')
+  openid: require('./openid'),
+  delegated: require('./delegated')
 };

--- a/config/routes.js
+++ b/config/routes.js
@@ -5,6 +5,7 @@ module.exports.routes = {
   'post /auth/local': 'AuthController.callback',
   'post /auth/local/:action': 'AuthController.callback',
 
+  'post /auth/:provider': 'AuthController.callback',
   'post /auth/:provider/:action': 'AuthController.callback',
 
   'get /auth/:provider': 'AuthController.provider',

--- a/config/routes.js
+++ b/config/routes.js
@@ -5,6 +5,8 @@ module.exports.routes = {
   'post /auth/local': 'AuthController.callback',
   'post /auth/local/:action': 'AuthController.callback',
 
+  'post /auth/:provider/:action': 'AuthController.callback',
+
   'get /auth/:provider': 'AuthController.provider',
   'get /auth/:provider/callback': 'AuthController.callback',
   'get /auth/:provider/:action': 'AuthController.callback'


### PR DESCRIPTION
Authentication is delegated by the Strategy to an external provider but handled locally (e.g. makes request internally to external provider) unlike OAuth or similar which redirects to the external provider. On success the authenticated user is connected to a local user (created if necessary) in a similar manner to OAuth.

Add new POST route to support delegated authentication, which requires the ability to post a login form in a manner similar to the local protocol.

Add support for the `info` and `status` parameters of the `passport.authenticate()` callback method.